### PR TITLE
Configurable API timeout.

### DIFF
--- a/cli/src/cfg/Config.schema.yaml
+++ b/cli/src/cfg/Config.schema.yaml
@@ -11,19 +11,24 @@ properties:
         type: string
         minLength: 1
 
-      management-token:
+      base-url:
         type: string
-        minLength: 1
+        minLength: 8
+        format: uri
 
       branch:
         type: string
         minLength: 1
         default: main
 
-      base-url:
+      management-token:
         type: string
-        minLength: 8
-        format: uri
+        minLength: 1
+
+      timeout:
+        type: integer
+        minimum: 1
+        default: 10000
 
   schema:
     type: object

--- a/cli/src/cfg/transform.ts
+++ b/cli/src/cfg/transform.ts
@@ -25,6 +25,7 @@ function transformClientConfig(configData: Config) {
 		baseUrl: rawBaseUrl ? new URL(rawBaseUrl) : undefined,
 		branch: x.branch,
 		managementToken: x['management-token'],
+		timeout: x.timeout,
 	};
 }
 

--- a/cli/src/cs/api/Client.ts
+++ b/cli/src/cs/api/Client.ts
@@ -17,7 +17,7 @@ export function createClient(ui: UiContext) {
 }
 
 function createBaseClient(ui: UiContext) {
-	const stallCatcher = new TimeoutAndRetryBehavior();
+	const stallCatcher = new TimeoutAndRetryBehavior(ui.options.client.timeout);
 
 	stallCatcher.on('stall-encountered', (request, attempts, maxAttempts) => {
 		const y = createStylus('yellowBright');

--- a/cli/src/cs/api/stall/RequestWithTimeout.ts
+++ b/cli/src/cs/api/stall/RequestWithTimeout.ts
@@ -1,11 +1,9 @@
 import ApiTimeoutError from './ApiTimeoutError.js';
 
-const stallTimeout = 10000; // arbitrary.
-
 export default class RequestWithTimeout extends Request implements Disposable {
 	readonly #timer: NodeJS.Timeout;
 
-	public constructor(request: Request) {
+	public constructor(request: Request, timeout: number) {
 		const controller = new AbortController();
 
 		super(request, {
@@ -14,7 +12,7 @@ export default class RequestWithTimeout extends Request implements Disposable {
 
 		this.#timer = setTimeout(
 			() => controller.abort(new ApiTimeoutError()),
-			stallTimeout,
+			timeout,
 		);
 	}
 

--- a/cli/src/cs/api/stall/TimeoutAndRetryBehavior.ts
+++ b/cli/src/cs/api/stall/TimeoutAndRetryBehavior.ts
@@ -10,6 +10,10 @@ interface EventMap {
 }
 
 export default class TimeoutAndRetryBehavior extends EventEmitter<EventMap> {
+	public constructor(private readonly _timeout: number) {
+		super();
+	}
+
 	public async fetch(...args: Parameters<typeof fetch>) {
 		const [original] = args;
 
@@ -20,7 +24,7 @@ export default class TimeoutAndRetryBehavior extends EventEmitter<EventMap> {
 		let attempts = 0;
 
 		do {
-			using antiStallRequest = new RequestWithTimeout(original);
+			using antiStallRequest = new RequestWithTimeout(original, this._timeout);
 
 			try {
 				return await fetch(antiStallRequest);

--- a/cli/src/ui/Options.ts
+++ b/cli/src/ui/Options.ts
@@ -6,6 +6,7 @@ export default interface Options {
 		readonly baseUrl: URL;
 		readonly branch: string;
 		readonly managementToken: string;
+		readonly timeout: number;
 	};
 	readonly configFile: PathLike;
 	readonly schema: {

--- a/cli/src/ui/UiOptions.ts
+++ b/cli/src/ui/UiOptions.ts
@@ -1,6 +1,10 @@
 import type Options from './Options.js';
 import { DefaultTaxonomyStrategies } from './Options.js';
 import type { PartialOptions } from './PartialOptions.js';
+import { defaultValue as defaultTimeout } from './option/apiTimeout.js';
+import { defaultValue as defaultBranch } from './option/branch.js';
+import { defaultValue as defaultStrategy } from './option/deletionStrategy.js';
+import { defaultValue as defaultSchemaPath } from './option/schemaPath.js';
 
 export default class UiOptions implements Options {
 	public readonly client: Options['client'];
@@ -33,8 +37,9 @@ function client(...others: PartialOptions['client'][]): Options['client'] {
 	return {
 		apiKey: other?.apiKey ?? '',
 		baseUrl: other?.baseUrl ?? new URL('http://localhost'),
-		branch: other?.branch ?? 'main',
+		branch: other?.branch ?? defaultBranch,
 		managementToken: other?.managementToken ?? '',
+		timeout: other?.timeout ?? defaultTimeout,
 	};
 }
 
@@ -43,10 +48,10 @@ function schema(...others: PartialOptions['schema'][]): Options['schema'] {
 
 	return {
 		assets: assets(...others.map((o) => o?.assets)),
-		deletionStrategy: other?.deletionStrategy ?? 'warn',
+		deletionStrategy: other?.deletionStrategy ?? defaultStrategy,
 		extension: maps(...others.map((o) => o?.extension)),
 		jsonRtePlugin: maps(...others.map((o) => o?.jsonRtePlugin)),
-		schemaPath: other?.schemaPath ?? '',
+		schemaPath: other?.schemaPath ?? defaultSchemaPath,
 		taxonomies: other?.taxonomies ?? DefaultTaxonomyStrategies,
 	};
 }

--- a/cli/src/ui/command/clear.ts
+++ b/cli/src/ui/command/clear.ts
@@ -12,6 +12,7 @@ import { Store } from '../../schema/lib/SchemaUi.js';
 const clear = new Command('clear');
 
 clear
+	.addOption(Options.apiTimeout)
 	.addOption(Options.apiKey)
 	.addOption(Options.baseUrl)
 	.addOption(Options.branch)
@@ -20,6 +21,7 @@ clear
 	.description('Empty all data from a stack.');
 
 type CommandOptions = Options.ApiKeyOption &
+	Options.ApiTimeoutOption &
 	Options.BaseUrlOption &
 	Options.BranchOption &
 	Options.ManagementTokenOption &
@@ -52,6 +54,7 @@ async function mapOptions(options: CommandOptions) {
 			baseUrl: options.baseUrl,
 			branch: options.branch,
 			managementToken: options.managementToken,
+			timeout: options.apiTimeout,
 		},
 		schema: {
 			deletionStrategy: 'delete',

--- a/cli/src/ui/command/pull.ts
+++ b/cli/src/ui/command/pull.ts
@@ -16,6 +16,7 @@ import { resolve } from 'node:path';
 const pull = new Command('pull');
 
 pull
+	.addOption(Options.apiTimeout)
 	.addOption(Options.apiKey)
 	.addOption(Options.baseUrl)
 	.addOption(Options.branch)
@@ -27,6 +28,7 @@ pull
 	.description('Serialize data and schema from a stack into the file system.');
 
 type CommandOptions = Options.ApiKeyOption &
+	Options.ApiTimeoutOption &
 	Options.BaseUrlOption &
 	Options.BranchOption &
 	Options.ExtensionOption &
@@ -68,6 +70,7 @@ async function mapOptions(options: CommandOptions) {
 			baseUrl: options.baseUrl,
 			branch: options.branch,
 			managementToken: options.managementToken,
+			timeout: options.apiTimeout,
 		},
 		schema: {
 			deletionStrategy: 'delete',

--- a/cli/src/ui/command/push.ts
+++ b/cli/src/ui/command/push.ts
@@ -1,5 +1,8 @@
+import resolveConfig from '#cli/cfg/resolveConfig.js';
 import { createClient } from '#cli/cs/api/Client.js';
+import { Store } from '#cli/schema/lib/SchemaUi.js';
 import pushJob from '#cli/schema/push.js';
+import SchemaOperationError from '#cli/schema/SchemaOperationError.js';
 import createStylus from '#cli/ui/createStylus.js';
 import HandledError from '#cli/ui/HandledError.js';
 import humanizePath from '#cli/ui/humanizePath.js';
@@ -9,13 +12,11 @@ import * as Options from '#cli/ui/option/index.js';
 import { ConsoleUiContext } from '#cli/ui/UiContext.js';
 import { Command } from 'commander';
 import { resolve } from 'node:path';
-import resolveConfig from '../../cfg/resolveConfig.js';
-import { Store } from '../../schema/lib/SchemaUi.js';
-import SchemaOperationError from '../../schema/SchemaOperationError.js';
 
 const push = new Command('push');
 
 push
+	.addOption(Options.apiTimeout)
 	.addOption(Options.apiKey)
 	.addOption(Options.baseUrl)
 	.addOption(Options.branch)
@@ -28,6 +29,7 @@ push
 	.description('Deploy serialized data and schema into a stack.');
 
 type CommandOptions = Options.ApiKeyOption &
+	Options.ApiTimeoutOption &
 	Options.BaseUrlOption &
 	Options.BranchOption &
 	Options.DeletionStrategyOption &
@@ -70,6 +72,7 @@ async function mapOptions(options: CommandOptions) {
 			baseUrl: options.baseUrl,
 			branch: options.branch,
 			managementToken: options.managementToken,
+			timeout: options.apiTimeout,
 		},
 		schema: {
 			deletionStrategy: options.deletionStrategy,

--- a/cli/src/ui/option/apiTimeout.ts
+++ b/cli/src/ui/option/apiTimeout.ts
@@ -1,0 +1,24 @@
+import { InvalidArgumentError, Option } from 'commander';
+import type Options from '../Options.js';
+
+const apiTimeout = new Option('--api-timeout [ms]', 'Contentstack API timeout');
+
+export const defaultValue = 10000;
+apiTimeout.argParser(timeoutParser).default(defaultValue);
+
+export interface ApiTimeoutOption {
+	readonly apiTimeout: Options['client']['timeout'];
+}
+
+export default apiTimeout;
+
+function timeoutParser(value: string): number {
+	const parsedValue = parseInt(value, 10);
+
+	if (isNaN(parsedValue) || parsedValue <= 0) {
+		const msg = 'Invalid timeout value. Must be a positive number.';
+		throw new InvalidArgumentError(msg);
+	}
+
+	return parsedValue;
+}

--- a/cli/src/ui/option/branch.ts
+++ b/cli/src/ui/option/branch.ts
@@ -3,7 +3,7 @@ import type Options from '../Options.js';
 
 const branch = new Option('--branch [name]', 'Contentstack Branch');
 
-const defaultValue = 'main';
+export const defaultValue = 'main';
 
 branch
 	.env('Contentstack_Branch')

--- a/cli/src/ui/option/deletionStrategy.ts
+++ b/cli/src/ui/option/deletionStrategy.ts
@@ -6,9 +6,11 @@ const deletionStrategy = new Option(
 	'How to handle deletions in the target stack',
 );
 
+export const defaultValue = 'warn';
+
 deletionStrategy
 	.choices(['delete', 'ignore', 'warn'])
-	.default('warn')
+	.default(defaultValue)
 	.makeOptionMandatory();
 
 export interface DeletionStrategyOption {

--- a/cli/src/ui/option/index.ts
+++ b/cli/src/ui/option/index.ts
@@ -1,5 +1,7 @@
 export { default as apiKey } from './apiKey.js';
 export type { ApiKeyOption } from './apiKey.js';
+export { default as apiTimeout } from './apiTimeout.js';
+export type { ApiTimeoutOption } from './apiTimeout.js';
 export { default as baseUrl } from './baseUrl.js';
 export type { BaseUrlOption } from './baseUrl.js';
 export { default as branch } from './branch.js';

--- a/cli/src/ui/option/schemaPath.ts
+++ b/cli/src/ui/option/schemaPath.ts
@@ -7,8 +7,10 @@ const schemaPath = new Option(
 	'Output Contentstack schema files to the provided folder.',
 );
 
+export const defaultValue = './cs/schema';
+
 schemaPath
-	.default('./cs/schema')
+	.default(defaultValue)
 	.argParser((path) => resolve(path))
 	.makeOptionMandatory();
 

--- a/test/integration/lib/TestPushUiContext.ts
+++ b/test/integration/lib/TestPushUiContext.ts
@@ -27,6 +27,7 @@ export default class TestPushUiContext extends TestUiContext {
 					baseUrl: new URL(baseUrl),
 					branch: 'main',
 					managementToken,
+					timeout: 30000,
 				},
 				configFile: '',
 				schema: {


### PR DESCRIPTION
If merged, this PR will introduce a new config option, `--api-timeout` on the command line or `client.timeout` in the config file, which will control the number of milliseconds the system will wait before declaring that the API has taken too long to respond.