### PR TITLE
Improve YAML formatting for leading/trailing non-breaking spaces

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Some test snapshots are sensitive to whitespace and should not be
+# handled by prettier
+test/snapshots/leading-unicode.yaml
+test/snapshots/normalize-exported-schema.yaml

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -2,3 +2,10 @@ trailingComma: all
 tabWidth: 2
 semi: true
 singleQuote: true
+
+overrides:
+  - files:
+      - '*.json'
+      - '*.jsonc'
+    options:
+      trailingComma: none

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -65,7 +65,8 @@
 	},
 	"files.readonlyInclude": {
 		"**/node_modules/**": true,
-		"cli/src/cs/api/cma-openapi-3.d.ts": true
+		"cli/src/cs/api/cma-openapi-3.d.ts": true,
+		"test/snapshots/*.yaml": true
 	},
 	"javascript.preferences.importModuleSpecifier": "project-relative",
 	"javascript.preferences.importModuleSpecifierEnding": "js",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,22 +9,6 @@
 	},
 	"editor.defaultFormatter": "esbenp.prettier-vscode",
 	"editor.formatOnSave": true,
-	"eslint.useFlatConfig": true,
-	"files.associations": {
-		".env.example": "properties"
-	},
-	"files.readonlyInclude": {
-		"**/node_modules/**": true,
-		"cli/src/cs/api/cma-openapi-3.d.ts": true
-	},
-	"javascript.preferences.importModuleSpecifier": "project-relative",
-	"javascript.preferences.importModuleSpecifierEnding": "js",
-	"npm.packageManager": "yarn",
-	"typescript.preferences.importModuleSpecifier": "project-relative",
-	"typescript.preferences.importModuleSpecifierEnding": "js",
-	"typescript.preferences.preferTypeOnlyAutoImports": true,
-	"typescript.tsc.autoDetect": "off",
-	"typescript.tsdk": "node_modules/typescript/lib",
 	"eslint.rules.customizations": [
 		{
 			"rule": "@typescript-eslint/consistent-type-imports",
@@ -74,5 +58,25 @@
 			"rule": "sort-keys",
 			"severity": "off"
 		}
-	]
+	],
+	"eslint.useFlatConfig": true,
+	"files.associations": {
+		".env.example": "properties"
+	},
+	"files.readonlyInclude": {
+		"**/node_modules/**": true,
+		"cli/src/cs/api/cma-openapi-3.d.ts": true
+	},
+	"javascript.preferences.importModuleSpecifier": "project-relative",
+	"javascript.preferences.importModuleSpecifierEnding": "js",
+	"npm.packageManager": "yarn",
+	"search.exclude": {
+		"**/node_modules": true,
+		"yarn.lock": true
+	},
+	"typescript.preferences.importModuleSpecifier": "project-relative",
+	"typescript.preferences.importModuleSpecifierEnding": "js",
+	"typescript.preferences.preferTypeOnlyAutoImports": true,
+	"typescript.tsc.autoDetect": "off",
+	"typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -12,7 +12,6 @@
     "cli-progress": "^3.12.0",
     "commander": "^13.1.0",
     "http-status-codes": "^2.3.0",
-    "js-yaml": "^4.1.0",
     "mime": "^4.0.7",
     "minimatch": "^10.0.1",
     "openapi-fetch": "^0.13.5",
@@ -24,7 +23,6 @@
   "devDependencies": {
     "@types/asciichart": "^1.5.8",
     "@types/cli-progress": "^3.11.6",
-    "@types/js-yaml": "^4",
     "@types/node": "^22.14.0",
     "json-schema-to-typescript": "^15.0.4",
     "openapi-typescript": "^7.6.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -18,13 +18,14 @@
     "openapi-fetch": "^0.13.5",
     "prettier": "^3.5.3",
     "sanitize-filename": "^1.6.3",
-    "tslib": "^2.8.1"
+    "tslib": "^2.8.1",
+    "yaml": "^2.7.1"
   },
   "description": "Beacon facilitates serialization and deserialization of Contentstack content",
   "devDependencies": {
     "@types/asciichart": "^1.5.8",
     "@types/cli-progress": "^3.11.6",
-    "@types/js-yaml": "^4.0.9",
+    "@types/js-yaml": "^4",
     "@types/node": "^22.14.0",
     "json-schema-to-typescript": "^15.0.4",
     "openapi-typescript": "^7.6.1",

--- a/cli/package.json
+++ b/cli/package.json
@@ -16,7 +16,6 @@
     "mime": "^4.0.7",
     "minimatch": "^10.0.1",
     "openapi-fetch": "^0.13.5",
-    "prettier": "^3.5.3",
     "sanitize-filename": "^1.6.3",
     "tslib": "^2.8.1",
     "yaml": "^2.7.1"

--- a/cli/src/cfg/createSchemaValidationFn.ts
+++ b/cli/src/cfg/createSchemaValidationFn.ts
@@ -1,7 +1,6 @@
 import { Ajv } from 'ajv';
 import formats from 'ajv-formats';
-import yaml from 'js-yaml';
-import { readFile } from 'node:fs/promises';
+import readYaml from '../fs/readYaml.js';
 import isRecord from '../util/isRecord.js';
 import type { Config } from './Config.schema.yaml';
 
@@ -15,8 +14,7 @@ export default async function createSchemaValidationFn() {
 	addFormats(ajv);
 
 	const schemaUrl = new URL('./Config.schema.yaml', import.meta.url);
-	const schemaFile = await readFile(schemaUrl, 'utf8');
-	const schema = yaml.load(schemaFile);
+	const schema = await readYaml(schemaUrl);
 	if (!isRecord(schema)) {
 		throw new Error('Invalid schema');
 	}

--- a/cli/src/cfg/loadConfig.ts
+++ b/cli/src/cfg/loadConfig.ts
@@ -1,6 +1,6 @@
-import yaml from 'js-yaml';
 import type { PathLike } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { parse } from 'yaml';
 import type { PartialOptions } from '../ui/PartialOptions.js';
 import ConfigMissingError from './ConfigMissingError.js';
 import ConfigurationError from './ConfigurationError.js';
@@ -32,7 +32,7 @@ export default async function loadConfig(
 		);
 	}
 
-	const cfg = yaml.load(raw);
+	const cfg: unknown = parse(raw);
 	const validate = await createSchemaValidationFn();
 
 	if (!validate(cfg)) {

--- a/cli/src/cs/api/ContentstackError.test.ts
+++ b/cli/src/cs/api/ContentstackError.test.ts
@@ -1,6 +1,6 @@
 import readFixture from '#test/fixtures/readFixture';
-import yaml from 'js-yaml';
 import { expect, test, vi } from 'vitest';
+import { parse } from 'yaml';
 import ContentstackError from './ContentstackError.js';
 
 vi.mock(import('../../ui/HandledError.js'));
@@ -8,7 +8,7 @@ vi.mock(import('../../ui/HandledError.js'));
 test('Correctly understands a Contentstack error response', async () => {
 	// Arrange
 	const errorYaml = await readFixture('error-response.yaml');
-	const errorResponse = yaml.load(errorYaml);
+	const errorResponse: unknown = parse(errorYaml);
 
 	// Act
 	const fn = () => ContentstackError.throwIfError(errorResponse, 'unit test');

--- a/cli/src/fs/readYaml.ts
+++ b/cli/src/fs/readYaml.ts
@@ -1,0 +1,8 @@
+import type { PathLike } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { parse } from 'yaml';
+
+export default async function readYaml(pathLike: PathLike): Promise<unknown> {
+	const raw = await readFile(pathLike, 'utf-8');
+	return parse(raw);
+}

--- a/cli/src/fs/writeYaml.test.ts
+++ b/cli/src/fs/writeYaml.test.ts
@@ -1,0 +1,34 @@
+import readFixture from '#test/fixtures/readFixture.js';
+import getSnapshotPath from '#test/snapshots/getSnapshotPath.js';
+import TempFolder from '#test/util/TempFolder.js';
+import TestProjectUrl from '#test/util/TestProjectUrl.js';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import writeYaml from './writeYaml.js';
+
+describe(writeYaml.name, () => {
+	it('can serialize troublesome unicode characters', async () => {
+		// Arrange
+		const tempPath = fileURLToPath(new URL('.tmp', TestProjectUrl));
+		await using tempFolder = await TempFolder.create(tempPath);
+		const outputName = 'output.yaml';
+		const absolutePath = resolve(tempFolder.absPath, outputName);
+		const content = await readJsonC('serialization/leading-unicode.jsonc');
+
+		// Act
+		await writeYaml(absolutePath, content);
+		const actual = await readFile(absolutePath, 'utf-8');
+
+		// Assert
+		const snapPath = getSnapshotPath('leading-unicode.yaml');
+		await expect(actual).toMatchFileSnapshot(snapPath);
+	});
+});
+
+async function readJsonC(fixturePath: string): Promise<unknown> {
+	const raw = await readFixture(fixturePath);
+	const withoutComments = raw.replace(/\/\/.*|\/\*[\s\S]*?\*\//gu, '').trim();
+	return JSON.parse(withoutComments);
+}

--- a/cli/src/fs/writeYaml.ts
+++ b/cli/src/fs/writeYaml.ts
@@ -1,14 +1,15 @@
 import { mkdir, writeFile } from 'fs/promises';
-import yaml from 'js-yaml';
 import { dirname } from 'node:path';
 import prettier from 'prettier';
+import type { SchemaOptions } from 'yaml';
+import { stringify } from 'yaml';
 
 export default async function writeYaml(
 	absolutePath: string,
 	content: unknown,
-	opts: yaml.DumpOptions = { sortKeys: true },
+	opts: SchemaOptions = { sortMapEntries: true },
 ) {
-	const ugly = yaml.dump(content, opts);
+	const ugly = stringify(content, opts);
 
 	const [pretty] = await Promise.all([
 		format(absolutePath, ugly),

--- a/cli/src/fs/writeYaml.ts
+++ b/cli/src/fs/writeYaml.ts
@@ -1,6 +1,5 @@
 import { mkdir, writeFile } from 'fs/promises';
 import { dirname } from 'node:path';
-import prettier from 'prettier';
 import type { SchemaOptions } from 'yaml';
 import { stringify } from 'yaml';
 
@@ -9,17 +8,7 @@ export default async function writeYaml(
 	content: unknown,
 	opts: SchemaOptions = { sortMapEntries: true },
 ) {
-	const ugly = stringify(content, opts);
-
-	const [pretty] = await Promise.all([
-		format(absolutePath, ugly),
-		mkdir(dirname(absolutePath), { recursive: true }),
-	]);
-
-	await writeFile(absolutePath, pretty, 'utf-8');
-}
-
-async function format(absolutePath: string, yamlContent: string) {
-	const options = await prettier.resolveConfig(absolutePath);
-	return prettier.format(yamlContent, { ...options, parser: 'yaml' });
+	const output = stringify(content, opts);
+	await mkdir(dirname(absolutePath), { recursive: true });
+	await writeFile(absolutePath, output, 'utf-8');
 }

--- a/cli/src/schema/assets/lib/MetaSerialization.ts
+++ b/cli/src/schema/assets/lib/MetaSerialization.ts
@@ -1,7 +1,7 @@
+import readYaml from '#cli/fs/readYaml.js';
 import writeYaml from '#cli/fs/writeYaml.js';
 import isRecord from '#cli/util/isRecord.js';
-import yaml from 'js-yaml';
-import { readFile, stat } from 'node:fs/promises';
+import { stat } from 'node:fs/promises';
 import type AssetMeta from '../AssetMeta.js';
 import { getMetaPath } from './NamingConvention.js';
 
@@ -26,12 +26,10 @@ export async function load(paths: {
 	readonly itemPath: string;
 	readonly metaPath: string;
 }): Promise<AssetMeta> {
-	const [raw, blobStats] = await Promise.all([
-		readFile(paths.metaPath, 'utf-8'),
+	const [parsed, blobStats] = await Promise.all([
+		readYaml(paths.metaPath),
 		stat(paths.blobPath),
 	]);
-
-	const parsed = yaml.load(raw);
 
 	if (!isRawMeta(parsed)) {
 		throw new Error(`Invalid asset metadata: ${paths.metaPath}`);

--- a/cli/src/schema/ctx/lib/FsTaxonomyCollection.ts
+++ b/cli/src/schema/ctx/lib/FsTaxonomyCollection.ts
@@ -37,7 +37,7 @@ export default class FsTaxonomyCollection implements TaxonomyCollection {
 
 	async #write(normalized: NormalizedTaxonomy) {
 		const path = this.#getPath(normalized.taxonomy.uid);
-		return writeYaml(path, normalized, { sortKeys: false });
+		return writeYaml(path, normalized, { sortMapEntries: false });
 	}
 
 	#getPath(uid: string) {

--- a/cli/src/schema/isEquivalentSchema.test.ts
+++ b/cli/src/schema/isEquivalentSchema.test.ts
@@ -1,7 +1,7 @@
 import type { Schema } from '#cli/cs/Types.js';
 import readFixture from '#test/fixtures/readFixture';
-import yaml from 'js-yaml';
 import { expect, test } from 'vitest';
+import { parse } from 'yaml';
 import isEquivalentSchema from './isEquivalentSchema.js';
 
 test('Equal schemas are equal', () => {
@@ -16,8 +16,8 @@ test('Equal schemas are equal', () => {
 			readFixture(`${fixtureName}-export.yaml`),
 		]);
 
-		const read = yaml.load(x) as Schema;
-		const exportFixture = yaml.load(y) as Schema;
+		const read = parse(x) as Schema;
+		const exportFixture = parse(y) as Schema;
 
 		expect(isEquivalentSchema(read, exportFixture)).toBe(true);
 	}),

--- a/cli/src/schema/normalize.test.ts
+++ b/cli/src/schema/normalize.test.ts
@@ -1,7 +1,6 @@
 import type { Schema } from '#cli/cs/Types.js';
 import readFixture from '#test/fixtures/readFixture';
 import getSnapshotPath from '#test/snapshots/getSnapshotPath';
-import prettier from 'prettier';
 import { expect, test } from 'vitest';
 import { parse, stringify } from 'yaml';
 import normalize from './normalize.js';
@@ -15,9 +14,7 @@ test('Normalization of an exported schema should match snapshot', async () => {
 	const normalized = normalize(exportFixture);
 
 	// Assert
-	const ugly = stringify(normalized, { sortMapEntries: true });
+	const output = stringify(normalized, { sortMapEntries: true });
 	const snapPath = getSnapshotPath('normalize-exported-schema.yaml');
-	const opts = await prettier.resolveConfig(snapPath);
-	const pretty = await prettier.format(ugly, { ...opts, parser: 'yaml' });
-	await expect(pretty).toMatchFileSnapshot(snapPath);
+	await expect(output).toMatchFileSnapshot(snapPath);
 });

--- a/cli/src/schema/normalize.test.ts
+++ b/cli/src/schema/normalize.test.ts
@@ -1,21 +1,21 @@
 import type { Schema } from '#cli/cs/Types.js';
 import readFixture from '#test/fixtures/readFixture';
 import getSnapshotPath from '#test/snapshots/getSnapshotPath';
-import yaml from 'js-yaml';
 import prettier from 'prettier';
 import { expect, test } from 'vitest';
+import { parse, stringify } from 'yaml';
 import normalize from './normalize.js';
 
 test('Normalization of an exported schema should match snapshot', async () => {
 	// Arrange
 	const fixtureYaml = await readFixture('navigation-export.yaml');
-	const exportFixture = yaml.load(fixtureYaml) as Schema;
+	const exportFixture = parse(fixtureYaml) as Schema;
 
 	// Act
 	const normalized = normalize(exportFixture);
 
 	// Assert
-	const ugly = yaml.dump(normalized, { sortKeys: true });
+	const ugly = stringify(normalized, { sortMapEntries: true });
 	const snapPath = getSnapshotPath('normalize-exported-schema.yaml');
 	const opts = await prettier.resolveConfig(snapPath);
 	const pretty = await prettier.format(ugly, { ...opts, parser: 'yaml' });

--- a/cli/src/schema/xfer/indexFromFilesystem.ts
+++ b/cli/src/schema/xfer/indexFromFilesystem.ts
@@ -1,7 +1,6 @@
+import readYaml from '#cli/fs/readYaml.js';
 import tryReadDir from '#cli/fs/tryReadDir.js';
 import isRecord from '#cli/util/isRecord.js';
-import yaml from 'js-yaml';
-import { readFile } from 'node:fs/promises';
 import { extname, resolve } from 'node:path';
 import { styleText } from 'node:util';
 import getUi from '../lib/SchemaUi.js';
@@ -24,8 +23,7 @@ export default async function indexFromFilesystem<
 		}
 
 		const fullPath = resolve(schemaPath, file.name);
-		const raw = await readFile(fullPath, 'utf-8');
-		const parsed = yaml.load(raw);
+		const parsed = await readYaml(fullPath);
 
 		if (!isRecord(parsed) || !typeGuard(parsed)) {
 			ui.warn(

--- a/test/fixtures/serialization/leading-unicode.jsonc
+++ b/test/fixtures/serialization/leading-unicode.jsonc
@@ -1,0 +1,10 @@
+// The text strings in this JSON file contain literals that appear to be
+// plain whitespace, but are actually Unicode characters with a misleading
+// appearance.
+//
+// The associated test is aimed at ensuring that we can correctly round-trip
+// these characters through the YAML parser and serializer.
+{
+	"text-1": " Receipts: ",
+	"text-2": " "
+}

--- a/test/integration/lib/createContentType.ts
+++ b/test/integration/lib/createContentType.ts
@@ -4,8 +4,8 @@ import importContentType from '#cli/cs/content-types/import.js';
 import type { ContentType } from '#cli/cs/content-types/Types.js';
 import type { Schema } from '#cli/cs/Types.js';
 import transform from '#cli/dto/schema/toCs.js';
-import yaml from 'js-yaml';
 import { randomUUID } from 'node:crypto';
+import { parse } from 'yaml';
 import readFixture from '../../fixtures/readFixture.js';
 
 export default async function createContentType(
@@ -16,7 +16,7 @@ export default async function createContentType(
 	const uid = title.toLowerCase().replaceAll('-', '_');
 
 	const fixture: Schema = {
-		...(yaml.load(fixtureYaml) as ContentType),
+		...(parse(fixtureYaml) as ContentType),
 		title,
 		uid,
 	};

--- a/test/integration/taxonomies/tests/pullTaxonomy.ts
+++ b/test/integration/taxonomies/tests/pullTaxonomy.ts
@@ -1,8 +1,7 @@
 import type Client from '#cli/cs/api/Client.js';
+import readYaml from '#cli/fs/readYaml.js';
 import { Store } from '#cli/schema/lib/SchemaUi.js';
 import pull from '#cli/schema/pull.js';
-import yaml from 'js-yaml';
-import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { expect } from 'vitest';
 import type { TestFixtures } from '../../lib/TestContext.js';
@@ -40,8 +39,7 @@ export default async function pullTaxonomy({
 			'new_taxonomy.yaml',
 		);
 
-		const raw = await readFile(expectedPath, 'utf8');
-		const parsed = yaml.load(raw);
+		const parsed = await readYaml(expectedPath);
 
 		expect(parsed).toEqual({
 			taxonomy: {

--- a/test/integration/taxonomies/tests/pushTerms.ts
+++ b/test/integration/taxonomies/tests/pushTerms.ts
@@ -1,10 +1,11 @@
 import exportTaxonomy from '#cli/cs/taxonomies/export.js';
+import readYaml from '#cli/fs/readYaml.js';
 import { Store } from '#cli/schema/lib/SchemaUi.js';
 import push from '#cli/schema/push.js';
-import yaml from 'js-yaml';
-import { readFile, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { expect } from 'vitest';
+import { stringify } from 'yaml';
 import type { TestFixtures } from '../../lib/TestContext.js';
 
 export default async function pushTerms({
@@ -44,7 +45,7 @@ export default async function pushTerms({
 
 async function updateSerializationToIncludeTerms(fixturePath: string) {
 	const path = resolve(fixturePath, 'taxonomies', 'new_taxonomy.yaml');
-	const existing = yaml.load(await readFile(path, 'utf8'));
+	const existing = await readYaml(path);
 
 	const term = (name: string, ...children: unknown[]) => ({
 		name,
@@ -54,7 +55,7 @@ async function updateSerializationToIncludeTerms(fixturePath: string) {
 
 	await writeFile(
 		path,
-		yaml.dump({
+		stringify({
 			...(existing as Record<string, unknown>),
 			terms: [
 				term('Term 1', term('Term 1.1'), term('Term 1.2'), term('Term 1.3')),

--- a/test/integration/workflow/tests/mutateGlobalField.ts
+++ b/test/integration/workflow/tests/mutateGlobalField.ts
@@ -1,11 +1,10 @@
 import type { Schema } from '#cli/cs/Types.js';
 import { isSchema } from '#cli/cs/Types.js';
+import readYaml from '#cli/fs/readYaml.js';
 import writeYaml from '#cli/fs/writeYaml.js';
 import schemaDirectory from '#cli/schema/global-fields/schemaDirectory.js';
 import { Store } from '#cli/schema/lib/SchemaUi.js';
 import push from '#cli/schema/push.js';
-import yaml from 'js-yaml';
-import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { expect } from 'vitest';
 import type { WorkflowFixtures } from '../lib/WorkflowTestContext.js';
@@ -36,8 +35,7 @@ export default async function mutateGlobalField({
 async function loadSeo() {
 	const globalFields = schemaDirectory();
 	const seoPath = resolve(globalFields, 'seo.yaml');
-	const rawSeo = await readFile(seoPath, 'utf-8');
-	const seo = yaml.load(rawSeo);
+	const seo = await readYaml(seoPath);
 
 	if (!isSchema(seo)) {
 		throw new Error('SEO schema is not valid');

--- a/test/integration/workflow/tests/pulledAssets.ts
+++ b/test/integration/workflow/tests/pulledAssets.ts
@@ -1,6 +1,6 @@
+import readYaml from '#cli/fs/readYaml.js';
 import { Store } from '#cli/schema/lib/SchemaUi.js';
-import yaml from 'js-yaml';
-import { readdir, readFile } from 'node:fs/promises';
+import { readdir } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { expect } from 'vitest';
 import type { WorkflowFixtures } from '../lib/WorkflowTestContext.js';
@@ -29,15 +29,12 @@ export default async function pulledAssets({
 			const pulledPath = resolve(pulled, name);
 			const fixturePath = resolve(original, name);
 
-			const [pulledRaw, fixtureRaw] = await Promise.all([
-				readFile(pulledPath, 'utf8'),
-				readFile(fixturePath, 'utf8'),
+			const [pulledContent, fixtureContent] = await Promise.all([
+				readYaml(pulledPath),
+				readYaml(fixturePath),
 			]);
 
-			const pulledParsed = yaml.load(pulledRaw);
-			const fixtureParsed = yaml.load(fixtureRaw);
-
-			expect(pulledParsed).toEqual(fixtureParsed);
+			expect(pulledContent).toEqual(fixtureContent);
 		}
 	});
 }

--- a/test/integration/workflow/tests/pulledContentTypes.ts
+++ b/test/integration/workflow/tests/pulledContentTypes.ts
@@ -1,6 +1,5 @@
+import readYaml from '#cli/fs/readYaml.js';
 import { Store } from '#cli/schema/lib/SchemaUi.js';
-import yaml from 'js-yaml';
-import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { expect } from 'vitest';
 import type { WorkflowFixtures } from '../lib/WorkflowTestContext.js';
@@ -15,7 +14,7 @@ export default async function pulledContentTypes({
 		const original = resolve(originalFixturePath, 'content-types');
 
 		const load = async (name: string) =>
-			yaml.load(await readFile(resolve(pulled, `${name}.yaml`), 'utf8'));
+			readYaml(resolve(pulled, `${name}.yaml`));
 
 		const [event, homePage] = await Promise.all([
 			load('event'),

--- a/test/integration/workflow/tests/pulledEntries.ts
+++ b/test/integration/workflow/tests/pulledEntries.ts
@@ -1,6 +1,5 @@
+import readYaml from '#cli/fs/readYaml.js';
 import { Store } from '#cli/schema/lib/SchemaUi.js';
-import yaml from 'js-yaml';
-import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { expect } from 'vitest';
 import type { WorkflowFixtures } from '../lib/WorkflowTestContext.js';
@@ -17,7 +16,7 @@ export default async function pulledEntries({
 
 		const load = async (dir: string, contentType: string, name: string) => {
 			const resolved = resolve(dir, contentType, `${name}.yaml`);
-			const parsed = await yaml.load(await readFile(resolved, 'utf8'));
+			const parsed = await readYaml(resolved);
 			return parsed as Record<string, unknown>;
 		};
 

--- a/test/integration/workflow/tests/pulledGlobalFields.ts
+++ b/test/integration/workflow/tests/pulledGlobalFields.ts
@@ -1,6 +1,5 @@
+import readYaml from '#cli/fs/readYaml.js';
 import { Store } from '#cli/schema/lib/SchemaUi.js';
-import yaml from 'js-yaml';
-import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { expect } from 'vitest';
 import type { WorkflowFixtures } from '../lib/WorkflowTestContext.js';
@@ -15,10 +14,8 @@ export default async function pulledGlobalFields({
 		const pulled = resolve(currentFixturePath, 'global-fields');
 		const original = resolve(originalFixturePath, 'global-fields');
 
-		const load = async (name: string) => {
-			const raw = await readFile(resolve(pulled, `${name}.yaml`), 'utf8');
-			return yaml.load(raw) as Record<string, unknown>;
-		};
+		const load = async (name: string) =>
+			readYaml(resolve(pulled, `${name}.yaml`));
 
 		const [contact, seo] = await Promise.all([load('contact'), load('seo')]);
 

--- a/test/integration/workflow/tests/pulledTaxonomies.ts
+++ b/test/integration/workflow/tests/pulledTaxonomies.ts
@@ -1,6 +1,6 @@
+import readYaml from '#cli/fs/readYaml.js';
 import { Store } from '#cli/schema/lib/SchemaUi.js';
-import yaml from 'js-yaml';
-import { readdir, readFile } from 'node:fs/promises';
+import { readdir } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { expect } from 'vitest';
 import type { WorkflowFixtures } from '../lib/WorkflowTestContext.js';
@@ -23,13 +23,11 @@ export default async function pulledTaxonomies({
 			const pulledPath = resolve(pulled, name);
 			const fixturePath = resolve(original, name);
 
-			const [pulledRaw, fixtureRaw] = await Promise.all([
-				readFile(pulledPath, 'utf8'),
-				readFile(fixturePath, 'utf8'),
+			const [pulledParsed, fixtureParsed] = await Promise.all([
+				readYaml(pulledPath),
+				readYaml(fixturePath),
 			]);
 
-			const pulledParsed = yaml.load(pulledRaw);
-			const fixtureParsed = yaml.load(fixtureRaw);
 			expect(pulledParsed).toEqual(fixtureParsed);
 		}
 	});

--- a/test/integration/workflow/tests/pushedEntries.ts
+++ b/test/integration/workflow/tests/pushedEntries.ts
@@ -2,10 +2,9 @@ import type { RawAssetItem } from '#cli/cs/assets/Types.js';
 import { isRawAsset } from '#cli/cs/assets/Types.js';
 import index from '#cli/cs/entries/index.js';
 import type { Entry } from '#cli/cs/entries/Types.js';
+import readYaml from '#cli/fs/readYaml.js';
 import { Store } from '#cli/schema/lib/SchemaUi.js';
 import isRecord from '#cli/util/isRecord.js';
-import yaml from 'js-yaml';
-import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { inspect } from 'node:util';
 import { expect } from 'vitest';
@@ -22,7 +21,7 @@ export default async function pushedEntries({
 
 		const load = async (dir: string, contentType: string, name: string) => {
 			const resolved = resolve(dir, contentType, `${name}.yaml`);
-			const parsed = await yaml.load(await readFile(resolved, 'utf8'));
+			const parsed = await readYaml(resolved);
 			return parsed as Record<string, unknown>;
 		};
 

--- a/test/package.json
+++ b/test/package.json
@@ -3,10 +3,8 @@
     "http-status-codes": "^2.3.0",
     "js-yaml": "^4.1.0",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "3.1.1"
-  },
-  "devDependencies": {
-    "@types/js-yaml": "^4.0.9"
+    "vitest": "3.1.1",
+    "yaml": "^2.7.1"
   },
   "imports": {
     "#cli/*": "../cli/src/*",
@@ -19,5 +17,8 @@
     "clean": "node ./build/clean.js"
   },
   "type": "module",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "devDependencies": {
+    "@types/js-yaml": "^4"
+  }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
     "http-status-codes": "^2.3.0",
-    "js-yaml": "^4.1.0",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "3.1.1",
     "yaml": "^2.7.1"
@@ -17,8 +16,5 @@
     "clean": "node ./build/clean.js"
   },
   "type": "module",
-  "version": "1.0.0",
-  "devDependencies": {
-    "@types/js-yaml": "^4"
-  }
+  "version": "1.0.0"
 }

--- a/test/snapshots/leading-unicode.yaml
+++ b/test/snapshots/leading-unicode.yaml
@@ -1,0 +1,2 @@
+text-1: ' Receipts: '
+text-2: ' '

--- a/test/snapshots/leading-unicode.yaml
+++ b/test/snapshots/leading-unicode.yaml
@@ -1,2 +1,2 @@
-text-1: ' Receipts: '
-text-2: ' '
+text-1:  Receipts: 
+text-2:  

--- a/test/snapshots/normalize-exported-schema.yaml
+++ b/test/snapshots/normalize-exported-schema.yaml
@@ -1,4 +1,4 @@
-description: ''
+description: ""
 options:
   is_page: false
   singleton: false

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,6 @@ __metadata:
     "@arke-systems/cs-rate-limit-middleware": "npm:^1.0.4"
     "@types/asciichart": "npm:^1.5.8"
     "@types/cli-progress": "npm:^3.11.6"
-    "@types/js-yaml": "npm:^4"
     "@types/node": "npm:^22.14.0"
     ajv: "npm:^8.17.1"
     ajv-formats: "npm:^3.0.1"
@@ -31,7 +30,6 @@ __metadata:
     cli-progress: "npm:^3.12.0"
     commander: "npm:^13.1.0"
     http-status-codes: "npm:^2.3.0"
-    js-yaml: "npm:^4.1.0"
     json-schema-to-typescript: "npm:^15.0.4"
     mime: "npm:^4.0.7"
     minimatch: "npm:^10.0.1"
@@ -50,9 +48,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@arke-systems/beacon-test@workspace:test"
   dependencies:
-    "@types/js-yaml": "npm:^4"
     http-status-codes: "npm:^2.3.0"
-    js-yaml: "npm:^4.1.0"
     vite-tsconfig-paths: "npm:^5.1.4"
     vitest: "npm:3.1.1"
     yaml: "npm:^2.7.1"
@@ -682,13 +678,6 @@ __metadata:
   version: 1.0.6
   resolution: "@types/estree@npm:1.0.6"
   checksum: 10c0/cdfd751f6f9065442cd40957c07fd80361c962869aa853c1c2fd03e101af8b9389d8ff4955a43a6fcfa223dd387a089937f95be0f3eec21ca527039fd2d9859a
-  languageName: node
-  linkType: hard
-
-"@types/js-yaml@npm:^4":
-  version: 4.0.9
-  resolution: "@types/js-yaml@npm:4.0.9"
-  checksum: 10c0/24de857aa8d61526bbfbbaa383aa538283ad17363fcd5bb5148e2c7f604547db36646440e739d78241ed008702a8920665d1add5618687b6743858fae00da211
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,7 +37,6 @@ __metadata:
     minimatch: "npm:^10.0.1"
     openapi-fetch: "npm:^0.13.5"
     openapi-typescript: "npm:^7.6.1"
-    prettier: "npm:^3.5.3"
     sanitize-filename: "npm:^1.6.3"
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@ __metadata:
     "@arke-systems/cs-rate-limit-middleware": "npm:^1.0.4"
     "@types/asciichart": "npm:^1.5.8"
     "@types/cli-progress": "npm:^3.11.6"
-    "@types/js-yaml": "npm:^4.0.9"
+    "@types/js-yaml": "npm:^4"
     "@types/node": "npm:^22.14.0"
     ajv: "npm:^8.17.1"
     ajv-formats: "npm:^3.0.1"
@@ -41,6 +41,7 @@ __metadata:
     sanitize-filename: "npm:^1.6.3"
     tslib: "npm:^2.8.1"
     typescript: "npm:^5.8.2"
+    yaml: "npm:^2.7.1"
   bin:
     beacon: ./dist/beacon.js
   languageName: unknown
@@ -50,11 +51,12 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@arke-systems/beacon-test@workspace:test"
   dependencies:
-    "@types/js-yaml": "npm:^4.0.9"
+    "@types/js-yaml": "npm:^4"
     http-status-codes: "npm:^2.3.0"
     js-yaml: "npm:^4.1.0"
     vite-tsconfig-paths: "npm:^5.1.4"
     vitest: "npm:3.1.1"
+    yaml: "npm:^2.7.1"
   languageName: unknown
   linkType: soft
 
@@ -684,7 +686,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/js-yaml@npm:^4.0.9":
+"@types/js-yaml@npm:^4":
   version: 4.0.9
   resolution: "@types/js-yaml@npm:4.0.9"
   checksum: 10c0/24de857aa8d61526bbfbbaa383aa538283ad17363fcd5bb5148e2c7f604547db36646440e739d78241ed008702a8920665d1add5618687b6743858fae00da211
@@ -3241,6 +3243,15 @@ __metadata:
   version: 0.0.43
   resolution: "yaml-ast-parser@npm:0.0.43"
   checksum: 10c0/4d2f1e761067b2c6abdd882279a406f879258787af470a6d4a659cb79cb2ab056b870b25f1f80f46ed556e8b499d611d247806376f53edf3412f72c0a8ea2e98
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.7.1":
+  version: 2.7.1
+  resolution: "yaml@npm:2.7.1"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/ee2126398ab7d1fdde566b4013b68e36930b9e6d8e68b6db356875c99614c10d678b6f45597a145ff6d63814961221fc305bf9242af8bf7450177f8a68537590
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
If merged, this PR will improve the serialization support for strings that contain leading or trailing non-breaking space characters.

This is accomplished by:

- Switching to a different YAML library; from [js-yaml][1] to [yaml][2]. This is partially due to js-yaml's [issue regarding NBSP characters][3].
- Removing support for invoking Prettier as part of the serialization process. I found that Prettier was incorrectly re-formatting YAML multi-line string blocks if those blocks began with an NBSP character. The formatting produced by the new yaml library is reasonably human-readable and will have to suffice.

[1]: https://github.com/nodeca/js-yaml 'js-yaml'
[2]: https://github.com/eemeli/yaml 'yaml'
[3]: https://github.com/nodeca/js-yaml/issues/650 'NBSP issue'
