### PR TITLE
Better handling for undefined booleans.

### DIFF
--- a/cli/src/cs/entryWalker/lib/node.ts
+++ b/cli/src/cs/entryWalker/lib/node.ts
@@ -8,14 +8,17 @@ export default function node(
 	schema: SchemaFields,
 	container: Record<string, unknown>,
 ) {
-	const entries = Object.entries(container);
-	if (entries.length === 0) {
+	const kvp = Object.entries(container);
+	if (kvp.length === 0) {
 		return container;
 	}
 
 	const properties = new Map<string, unknown>();
+	const seen = new Set<string>();
 
-	for (const [fieldUid, value] of entries) {
+	for (const [fieldUid, value] of kvp) {
+		seen.add(fieldUid);
+
 		if (fieldUid === '_metadata') {
 			properties.set(fieldUid, value);
 			continue;
@@ -35,6 +38,17 @@ export default function node(
 
 		if (processed !== undefined) {
 			properties.set(fieldUid, processed);
+		}
+	}
+
+	for (const field of schema) {
+		if (seen.has(field.uid)) {
+			continue;
+		}
+
+		const processed = this.field(field, undefined);
+		if (processed !== undefined) {
+			properties.set(field.uid, processed);
 		}
 	}
 

--- a/cli/src/dto/entry/lib/AssetReplacer.ts
+++ b/cli/src/dto/entry/lib/AssetReplacer.ts
@@ -6,8 +6,9 @@ import resolveItemPath from '#cli/schema/assets/lib/resolveItemPath.js';
 import type Ctx from '#cli/schema/ctx/Ctx.js';
 import getUi from '#cli/schema/lib/SchemaUi.js';
 import createStylus from '#cli/ui/createStylus.js';
+import type Replacer from './Replacer.js';
 
-export default class AssetReplacer {
+export default class AssetReplacer implements Replacer {
 	readonly #assetsByUid: ReadonlyMap<string, RawAssetItem>;
 	readonly #refPath: ReferencePath;
 

--- a/cli/src/dto/entry/lib/BooleanDefaults.ts
+++ b/cli/src/dto/entry/lib/BooleanDefaults.ts
@@ -1,0 +1,23 @@
+import type { SchemaField } from '#cli/cs/Types.js';
+import type Replacer from './Replacer.js';
+
+// 2024-04-06: Observed that an entry containing a boolean field that appears
+// as `false` in the UI may be exported as either `false` or entirely missing
+// from the JSON.
+//
+// If the field is really set to `false` in the JSON, everything is fine.
+//
+// However, if the field is missing from the JSON, then importing the entry
+// into a different stack will cause the field to be set to `false`, which
+// is good, but then if a second import takes place, the field is detected
+// as being different (`false !== undefined`), so the entry is re-imported.
+//
+// We wish to avoid this re-import behavior. To do so, we detect missing
+// boolean fields and set them to `false` as we read the entry from CS.
+export default class BooleanDefaults implements Replacer {
+	public process(schema: SchemaField, value: unknown) {
+		return schema.data_type === 'boolean' && value === undefined
+			? false
+			: value;
+	}
+}

--- a/cli/src/dto/entry/lib/JsonRteReplacer.ts
+++ b/cli/src/dto/entry/lib/JsonRteReplacer.ts
@@ -7,8 +7,9 @@ import getUi from '#cli/schema/lib/SchemaUi.js';
 import createStylus from '#cli/ui/createStylus.js';
 import isRecord from '#cli/util/isRecord.js';
 import { inspect } from 'node:util';
+import type Replacer from './Replacer.js';
 
-export default class JsonRteReplacer {
+export default class JsonRteReplacer implements Replacer {
 	readonly #assetsByUid: ReadonlyMap<string, RawAssetItem>;
 	readonly #refPath: ReferencePath;
 

--- a/cli/src/dto/entry/lib/ReferenceReplacer.ts
+++ b/cli/src/dto/entry/lib/ReferenceReplacer.ts
@@ -6,8 +6,9 @@ import type EntryCollection from '#cli/schema/entries/EntryCollection.js';
 import getUi from '#cli/schema/lib/SchemaUi.js';
 import createStylus from '#cli/ui/createStylus.js';
 import isRecord from '#cli/util/isRecord.js';
+import type Replacer from './Replacer.js';
 
-export default class ReferenceReplacer {
+export default class ReferenceReplacer implements Replacer {
 	readonly #refPath: ReferencePath;
 	readonly #entries: EntryCollection;
 
@@ -23,7 +24,7 @@ export default class ReferenceReplacer {
 	}
 
 	#replaceReferences(value: unknown) {
-		if (value === null) {
+		if (value === null || value === undefined) {
 			return;
 		}
 

--- a/cli/src/dto/entry/lib/Replacer.ts
+++ b/cli/src/dto/entry/lib/Replacer.ts
@@ -1,0 +1,5 @@
+import type { SchemaField } from '#cli/cs/Types.js';
+
+export default interface Replacer {
+	process(schema: SchemaField, value: unknown): unknown;
+}

--- a/cli/src/dto/entry/lib/ReplacerPipeline.ts
+++ b/cli/src/dto/entry/lib/ReplacerPipeline.ts
@@ -2,13 +2,11 @@ import type { ReferencePath } from '#cli/cs/entries/Types.js';
 import type { SchemaField } from '#cli/cs/Types.js';
 import type Ctx from '#cli/schema/ctx/Ctx.js';
 import AssetReplacer from './AssetReplacer.js';
+import BooleanDefaults from './BooleanDefaults.js';
 import JsonRteReplacer from './JsonRteReplacer.js';
 import ReferenceReplacer from './ReferenceReplacer.js';
+import type Replacer from './Replacer.js';
 import TaxonomyRemover from './TaxonomyRemover.js';
-
-interface Replacer {
-	process(schema: SchemaField, value: unknown): unknown;
-}
 
 export default class ReplacerPipeline {
 	readonly #replacers: Replacer[];
@@ -19,6 +17,7 @@ export default class ReplacerPipeline {
 			new ReferenceReplacer(ctx, refPath),
 			new JsonRteReplacer(ctx, refPath),
 			new TaxonomyRemover(refPath),
+			new BooleanDefaults(),
 		];
 	}
 

--- a/cli/src/dto/entry/lib/TaxonomyRemover.ts
+++ b/cli/src/dto/entry/lib/TaxonomyRemover.ts
@@ -3,9 +3,10 @@ import type { SchemaField } from '#cli/cs/Types.js';
 import getUi from '#cli/schema/lib/SchemaUi.js';
 import createStylus from '#cli/ui/createStylus.js';
 import taxonomyStrategy from '../../taxonomy/taxonomyStrategy.js';
+import type Replacer from './Replacer.js';
 import { isTaxonomyValue } from './TaxonomyValue.js';
 
-export default class TaxonomyRemover {
+export default class TaxonomyRemover implements Replacer {
 	readonly #refPath: ReferencePath;
 
 	public constructor(refPath: ReferencePath) {
@@ -19,7 +20,7 @@ export default class TaxonomyRemover {
 	}
 
 	#removeTaxonomies(value: unknown) {
-		if (value === null) {
+		if (value === null || value === undefined) {
 			return;
 		}
 


### PR DESCRIPTION
If merged, this PR will normalize the handling of boolean fields on entries when those entries do not provide a value.

I have observed that an entry containing a boolean field that appears as `false` in the UI may be exported as either `false` or entirely missing from the JSON.

If the field is really set to `false` in the JSON, everything is fine.

However, if the field is missing from the JSON, then importing the entry into a different stack will cause the field to be set to `false`, which is good, but then if a second import takes place, the field is detected as being different (`false !== undefined`), so the entry is re-imported.

We wish to avoid this re-import behavior. To do so, we detect missing boolean fields and set them to `false` as we read the entry from CS.