### PR TITLE
Shim rules

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -50,5 +50,5 @@
     "prepack": "node ./build/prepack.js"
   },
   "type": "module",
-  "version": "1.11.1"
+  "version": "1.11.2"
 }

--- a/cli/src/schema/content-types/reduceToShim.ts
+++ b/cli/src/schema/content-types/reduceToShim.ts
@@ -1,0 +1,36 @@
+import type { ContentType } from '#cli/cs/content-types/Types.js';
+import type { SchemaFields } from '#cli/cs/Types.js';
+import isRecord from '#cli/util/isRecord.js';
+
+export default function reduceToShim({
+	schema: originalSchema,
+	...rest
+}: ContentType): ContentType {
+	if (!Array.isArray(originalSchema)) {
+		throw new Error('Expected schema to be an array');
+	}
+
+	const schema = [findFieldByUid(originalSchema, 'title')];
+
+	const { options } = rest;
+	if (isRecord(options) && options.is_page === true) {
+		schema.push(findFieldByUid(originalSchema, 'url'));
+	}
+
+	const tax = schema.find((x) => isRecord(x) && x.data_type === 'taxonomy');
+	if (tax) {
+		schema.push(tax);
+	}
+
+	return { ...rest, schema };
+}
+
+function findFieldByUid(schema: SchemaFields, uid: string) {
+	const match = schema.find((x) => isRecord(x) && x.uid === uid);
+
+	if (!match) {
+		throw new Error(`Expected schema to have a ${uid} field`);
+	}
+
+	return match;
+}

--- a/cli/src/schema/content-types/reduceToShim.ts
+++ b/cli/src/schema/content-types/reduceToShim.ts
@@ -4,6 +4,7 @@ import isRecord from '#cli/util/isRecord.js';
 
 export default function reduceToShim({
 	schema: originalSchema,
+	field_rules,
 	...rest
 }: ContentType): ContentType {
 	if (!Array.isArray(originalSchema)) {

--- a/cli/src/schema/content-types/shimsToContentstack.ts
+++ b/cli/src/schema/content-types/shimsToContentstack.ts
@@ -1,12 +1,11 @@
 import importContentType from '#cli/cs/content-types/import.js';
 import type { ContentType } from '#cli/cs/content-types/Types.js';
-import type { SchemaFields } from '#cli/cs/Types.js';
-import isRecord from '#cli/util/isRecord.js';
 import type Ctx from '../ctx/Ctx.js';
 import isEquivalentSchema from '../isEquivalentSchema.js';
 import createProgressBar from '../lib/createProgressBar.js';
 import planMerge from '../xfer/lib/planMerge.js';
 import processPlan from '../xfer/lib/processPlan.js';
+import reduceToShim from './reduceToShim.js';
 
 // See /doc/lessons-learned/circular-references.md for the reasoning behind
 // this function.
@@ -40,37 +39,4 @@ async function noop() {
 	// no-op: content type shims are stand-ins for a full content type,
 	// and are only updated or updated when the full content type is removed
 	// or updated.
-}
-
-function reduceToShim({
-	schema: originalSchema,
-	...rest
-}: ContentType): ContentType {
-	if (!Array.isArray(originalSchema)) {
-		throw new Error('Expected schema to be an array');
-	}
-
-	const schema = [findFieldByUid(originalSchema, 'title')];
-
-	const { options } = rest;
-	if (isRecord(options) && options.is_page === true) {
-		schema.push(findFieldByUid(originalSchema, 'url'));
-	}
-
-	const tax = schema.find((x) => isRecord(x) && x.data_type === 'taxonomy');
-	if (tax) {
-		schema.push(tax);
-	}
-
-	return { ...rest, schema };
-}
-
-function findFieldByUid(schema: SchemaFields, uid: string) {
-	const match = schema.find((x) => isRecord(x) && x.uid === uid);
-
-	if (!match) {
-		throw new Error(`Expected schema to have a ${uid} field`);
-	}
-
-	return match;
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "yarn workspace @arke-systems/beacon-test vitest"
   },
   "type": "module",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "workspaces": [
     "cli",
     "test"

--- a/test/fixtures/developer-workflow/content-types/home_page.yaml
+++ b/test/fixtures/developer-workflow/content-types/home_page.yaml
@@ -1,4 +1,13 @@
 description: ''
+field_rules:
+  - actions:
+      - action: show
+        target_field: featured_events
+    conditions:
+      - operand_field: show_featured_events
+        operator: equals
+        value: true
+    match_type: all
 options:
   is_page: false
   singleton: true
@@ -168,6 +177,16 @@ schema:
         uid: thumbnail
         unique: false
     uid: links
+    unique: false
+  - data_type: boolean
+    display_name: Show Featured Events
+    field_metadata:
+      default_value: true
+      description: ''
+    mandatory: false
+    multiple: false
+    non_localizable: false
+    uid: show_featured_events
     unique: false
   - data_type: reference
     display_name: Featured Events

--- a/test/fixtures/developer-workflow/entries/home_page/Mice Community Hub.yaml
+++ b/test/fixtures/developer-workflow/entries/home_page/Mice Community Hub.yaml
@@ -83,5 +83,6 @@ main:
         - $beacon:
             asset: events/Bellmaker.webp
       title: Day at the Market
+show_featured_events: true
 tags: []
 title: Mice Community Hub


### PR DESCRIPTION
If merged, this PR will update the Content Type Shim logic to avoid including `field_rules` in the shim, since such rules are likely to refer to fields that are not present in the shim.

This is to address errors reported when attempting to create a shim with field rules, such as:

```
Error in Content Type Shims for page_general: ⚠ Failed to import content type: some_content_type_uid.
The Contentstack API reported an error (115): There was a problem importing the Content Type. Please correct the Content Type and try again.
Details: {
  'field_rules.0.conditions.0.operand_field': [ 'Invalid field UID.' ],
}
```

This PR also updates the version number.